### PR TITLE
Connect Advisor to Supabase vector store

### DIFF
--- a/dna-advisor/README.md
+++ b/dna-advisor/README.md
@@ -1,0 +1,20 @@
+# Dynamic Needs Analysis Advisor
+
+## Prequisites
+
+- **Python**: 3.12+
+
+## Setup
+
+1. **Create Virtual Environment**: `python3 -m venv venv`
+2. **Activate Virtual Environment**: `source venv/bin/activate`
+3. **Install Dependencies**: `python install -r requirements.txt`
+4. **Run the Api**: `python main.py`
+
+## Environment Variables
+
+|Environment Variable|Description|Default Value|
+|-|-|-|
+|DOCUMENTS|The directory where your documents reside|"./documents"|
+|SUPABASE_URL|The URL to your Supabase project|-|
+|SUPABASE_KEY|The service key for your Supabase project|-|

--- a/dna-advisor/lib/rag.py
+++ b/dna-advisor/lib/rag.py
@@ -9,7 +9,8 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain.schema.document import Document
 
 # DB
-from langchain.vectorstores.chroma import Chroma
+from supabase._sync.client import SyncClient
+from langchain_community.vectorstores.supabase import SupabaseVectorStore
 
 # ===================
 #   Data Processing
@@ -47,20 +48,19 @@ def chunk(documents: List[Document]):
     return text_splitter.split_documents(documents)
 
 
-# ===================
-#      ChromeDb
-# ===================
-
-
 class Rag:
-    def __init__(self, documents: Optional[List[Document]], embedding: Embeddings):
-        self._db = Chroma(
-            persist_directory="./chroma",
-            embedding_function=embedding
+    def __init__(self, supabase_client: SyncClient, documents: Optional[List[Document]], embedding: Embeddings):
+        self._db = SupabaseVectorStore(
+            client=supabase_client,
+            embedding=embedding,
+            table_name="documents",
+            query_name="match_documents",
         )
 
         if documents:
             self.add_documents(documents)
+        else:
+            print("[RAG] No documents provided.")
 
     @staticmethod
     def read_documents(dir: str):
@@ -82,32 +82,17 @@ class Rag:
 
     def add_documents(self, documents: List[Document]):
         chunks = embed_chunk_ids(chunk(documents))
+        print(f"[RAD] Adding {len(documents)} ({len(chunks)} chunks) documents to Supabase...")
+        self._db.add_documents(chunks)
 
-        # Get a list of existing embeddings in the database
-        existing_items = self._db.get(include=[])
-        existing_ids = set(existing_items["ids"])
-        print(f"Number of existing documents in DB: {len(existing_ids)}")
-
-        # Only add documents that don't exist in the DB.
-        new_chunks = []
-        for _chunk in chunks:
-            if _chunk.metadata["chunk_id"] not in existing_ids:
-                new_chunks.append(_chunk)
-
-        # If we have new chunks, we should add these documents to the database with a unique id
-        if len(new_chunks):
-            print(f"Chunks found: {len(new_chunks)}")
-            new_chunk_ids = [chunk.metadata["chunk_id"] for chunk in new_chunks]
-            self._db.add_documents(new_chunks, ids=new_chunk_ids)
-            self._db.persist()
+        # TODO: Add checks to filter out existing data and add only new chunks
 
     def get_context(self, prompt: str):
-        results = self._db.similarity_search_with_score(prompt, k=5)
+        results = self._db.similarity_search(prompt, k=5)
 
         context = []
 
-        for doc, _score in results:
-            print(_score)
+        for doc in results:
             context.append(doc.page_content)
 
         # # Print the sources used to generate context

--- a/dna-advisor/main.py
+++ b/dna-advisor/main.py
@@ -9,6 +9,9 @@ from api import create_api
 # Load model directly
 from huggingface_hub import hf_hub_download
 
+#
+from supabase.client import create_client
+
 
 # def find_model_template(model) -> str:
 #     template_file = os.path.splitext(model)[0] + '.json'
@@ -58,7 +61,12 @@ if __name__ == "__main__":
 
     # Load the documents to be embedded and stored in a vector db
     documents = Rag.read_documents(args.documents)
-    rag = Rag(documents=documents, embedding=model.getEmbeddings())
+
+    rag = None
+
+    if args.supabase_url and args.supabase_key:
+        supabase_client = create_client(args.supabase_url, args.supabase_key)
+        rag = Rag(supabase_client=supabase_client, documents=documents, embedding=model.getEmbeddings())
 
     # If there are no errors, tell the model to use RAG
     if rag:

--- a/dna-advisor/main.py
+++ b/dna-advisor/main.py
@@ -34,10 +34,14 @@ if __name__ == "__main__":
     DEFAULT_ADDRESS = "0.0.0.0"
     DEFAULT_PORT = 3001
     DOCUMENTS_DIR = os.getenv("DOCUMENTS", "./documents")
+    SUPABASE_URL = os.getenv("SUPABASE_URL")
+    SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", help="Address to bind the application to", default=DEFAULT_ADDRESS)
     parser.add_argument("--port", help="Port to bind the application to", default=DEFAULT_PORT)
+    parser.add_argument("--supabase-url", help="URL to your Supabase instance", default=SUPABASE_URL)
+    parser.add_argument("--supabase-key", help="Your Supabase access key", default=SUPABASE_KEY)
     parser.add_argument("-d", "--documents", help="Define the root documents directory", default=DOCUMENTS_DIR)
     args = parser.parse_args()
 

--- a/dna-advisor/requirements.txt
+++ b/dna-advisor/requirements.txt
@@ -26,6 +26,7 @@ cycler==0.12.1
 dataclasses-json==0.6.5
 deepdiff==7.0.1
 Deprecated==1.2.14
+deprecation==2.1.0
 diskcache==5.6.3
 dnspython==2.6.1
 effdet==0.4.1
@@ -45,6 +46,7 @@ google-api-core==2.19.0
 google-auth==2.29.0
 google-cloud-vision==3.7.2
 googleapis-common-protos==1.63.0
+gotrue==2.4.2
 gpt4all==2.6.0
 greenlet==3.0.3
 grpcio==1.63.0
@@ -132,6 +134,7 @@ pillow_heif==0.16.0
 plumbum==1.8.3
 ply==3.11
 portalocker==2.8.2
+postgrest==0.16.4
 posthog==3.5.0
 proto-plus==1.23.0
 protobuf==4.25.3
@@ -157,6 +160,7 @@ python-multipart==0.0.9
 pytz==2024.1
 PyYAML==6.0.1
 rapidfuzz==3.9.0
+realtime==1.0.4
 regex==2024.4.28
 requests==2.31.0
 requests-oauthlib==2.0.0
@@ -172,6 +176,10 @@ sniffio==1.3.1
 soupsieve==2.5
 SQLAlchemy==2.0.29
 starlette==0.37.2
+storage3==0.7.4
+StrEnum==0.4.15
+supabase==2.4.5
+supafunc==0.4.5
 sympy==1.12
 tabulate==0.9.0
 tenacity==8.2.3


### PR DESCRIPTION
### Summary
- Advisor connects to Supabase service via url and service key
- Advisor uploads documents to Supabase table

ChromaDB has been replaced with a Supabase client allowing for document embedding persistence outside of the service's local filesystem.

Some trade-offs has been as Supabase's vector store implementation has very little documentation for actions like retrieving the ids of embedding stored in Supabase. As a consequence, duplicated embeddings can (and will be) uploaded to the database when documents are re-processed. This should be fixed in a later commit.