### PR TITLE
Downgrade advisor docker image to bullseye

### DIFF
--- a/dna-advisor/Dockerfile
+++ b/dna-advisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 WORKDIR /app/
 


### PR DESCRIPTION
### Summary
 - Attempt to fix [CVE-2023-45853](https://www.cve.org/CVERecord?id=CVE-2023-45853)